### PR TITLE
Implement API

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,40 @@ If you need support for `solidus_frontend` please refer to the [README of solidu
 
 If you're using a custom frontend you'll need to adjust the code copied to your application by the installation generator. Given frontend choices can vary wildly, we can't provide a one-size-fits-all solution, but we are providing this simple integration with `solidus_starter_frontend` as a reference implementation. The amount of code is intentionally kept to a minimum, so you can easily adapt it to your needs.
 
+### API support
+
+The gem includes an API interface with two endpoints: `create_setup_intent` and `create_payment_intent`. 
+After configuring the gem, both endpoints will be accessible.
+
+#### Create Setup Intent
+
+This endpoint allows you to create an intent for configuring a saved payment method.
+It can be executed before making an actual payment to set up a card for future use.
+
+`POST /solidus_stripe/api/create_setup_intent`
+
+**Params**
+
+`payment_method_id`- ID of the `SolidusStripe::PaymentMethod` record
+
+#### Create Payment Intent
+
+This endpoint creates a payment intent for an order and returns a client secret that
+can be used to initialize Stripe's widget. Stripe later confirms the payment via a webhook call.
+
+`POST /solidus_stripe/api/create_payment_intent`
+
+This endpoint loads the last incomplete Spree order via the `last_incomplete_spree_order method`
+for a logged-in user, or it takes an optional `guest_token` parameter for a guest user.
+
+**Params**
+
+`payment_method_id` - ID of the `SolidusStripe::PaymentMethod` record
+
+`stripe_payment_method_id` - ID of the payment method, obtained by frontend from Stripe
+
+`guest_token` - optional
+
 ## Caveats
 
 ### Authorization and capture and checkout finalization

--- a/app/controllers/spree/solidus_stripe/api/intents_controller.rb
+++ b/app/controllers/spree/solidus_stripe/api/intents_controller.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Spree
+  module SolidusStripe
+    module Api
+      class IntentsController < Spree::Api::BaseController
+        before_action :load_order, only: :create_payment_intent
+        skip_before_action :authenticate_user, if: -> { params[:guest_token].present? }
+
+        def create_setup_intent
+          create_setup_intent_result = ::SolidusStripe::CreateSetupIntentForUser.new.call(
+            user: current_api_user,
+            payment_method_id: params[:payment_method_id],
+          )
+
+          render json: create_setup_intent_result
+        end
+
+        def create_payment_intent
+          authorize! :read, @order if current_api_user
+
+          create_payment_intent_result = ::SolidusStripe::CreatePaymentIntentForOrder.new(
+            order_id: @order.id,
+            payment_method_id: params[:payment_method_id],
+            stripe_payment_method_id: params[:stripe_payment_method_id]
+          ).call
+
+          render json: create_payment_intent_result
+        end
+
+        private
+
+        def load_order
+          @order = if current_api_user
+                     current_api_user.last_incomplete_spree_order
+                   else
+                     Spree::Order.find_by!(guest_token: params[:guest_token])
+                   end
+
+          render json: { error: "Order not found" }, status: :not_found unless @order
+        end
+      end
+    end
+  end
+end

--- a/app/models/solidus_stripe/customer.rb
+++ b/app/models/solidus_stripe/customer.rb
@@ -15,7 +15,21 @@ module SolidusStripe
     end
 
     def create_stripe_customer
-      payment_method.gateway.request { Stripe::Customer.create(email: source.email) }
+      payment_method.gateway.request { Stripe::Customer.create(email: source.email, name: customer_name) }
+    end
+
+    def customer_name
+      return full_name if full_name.present?
+
+      source.email
+    end
+
+    private
+
+    def full_name
+      return unless source.respond_to?(:first_name) && source.respond_to?(:last_name)
+
+      "#{source.first_name} #{source.last_name}".strip
     end
   end
 end

--- a/app/services/solidus_stripe/create_payment_intent_for_order.rb
+++ b/app/services/solidus_stripe/create_payment_intent_for_order.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module SolidusStripe
+  class CreatePaymentIntentForOrder
+    attr_reader :order, :payment_method_id, :stripe_payment_method_id
+
+    def initialize(order_id:, payment_method_id:, stripe_payment_method_id:)
+      @order = Spree::Order.find(order_id)
+      @payment_method_id = payment_method_id
+      @stripe_payment_method_id = stripe_payment_method_id
+    end
+
+    def call
+      payment_method = SolidusStripe::PaymentMethod.find(payment_method_id)
+      source = payment_source(payment_method: payment_method)
+
+      payment = order.payments.create!(
+        payment_method: payment_method,
+        amount: order.order_total_after_store_credit,
+        source: source
+      )
+
+      intent = SolidusStripe::PaymentIntent.prepare_for_payment(payment)
+
+      { client_secret: intent.stripe_intent.client_secret }
+    end
+
+    private
+
+    def payment_source(payment_method:)
+      SolidusStripe::PaymentSource.find_or_create_by!(
+        payment_method_id: payment_method.id,
+        stripe_payment_method_id: stripe_payment_method_id
+      )
+    end
+  end
+end

--- a/app/services/solidus_stripe/create_setup_intent_for_user.rb
+++ b/app/services/solidus_stripe/create_setup_intent_for_user.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module SolidusStripe
+  class CreateSetupIntentForUser
+    attr_reader :find_or_create_customer_for_user
+
+    def initialize(find_or_create_customer_for_user: FindOrCreateCustomerForUser)
+      @find_or_create_customer_for_user = find_or_create_customer_for_user
+    end
+
+    def call(user:, payment_method_id:)
+      payment_method = find_stripe_payment_method(payment_method_id: payment_method_id)
+      customer = find_or_create_customer_for_user.new(user: user, payment_method: payment_method).call
+
+      intent = setup_intent(customer, payment_method)
+
+      { client_secret: intent['client_secret'] }
+    end
+
+    private
+
+    def find_stripe_payment_method(payment_method_id:)
+      SolidusStripe::PaymentMethod.find(payment_method_id)
+    end
+
+    def setup_intent(customer, payment_method)
+      payment_method.gateway.request do
+        ::Stripe::SetupIntent.create({ customer: CGI.escape(customer.stripe_id) })
+      end
+    end
+  end
+end

--- a/app/services/solidus_stripe/find_or_create_customer_for_user.rb
+++ b/app/services/solidus_stripe/find_or_create_customer_for_user.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module SolidusStripe
+  class FindOrCreateCustomerForUser
+    attr_reader :user, :payment_method
+
+    def initialize(user:, payment_method:)
+      @user = user
+      @payment_method = payment_method
+    end
+
+    def call
+      customer = SolidusStripe::Customer.find_or_create_by!(source: user, payment_method: payment_method)
+      return customer if customer.stripe_id.present?
+
+      stripe_customer = customer.create_stripe_customer
+      customer.update!(stripe_id: stripe_customer.id)
+      customer
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,3 +6,12 @@ SolidusStripe::Engine.routes.draw do
     post :webhooks, to: 'webhooks#create', format: false
   end
 end
+
+Spree::Core::Engine.routes.draw do
+  namespace :solidus_stripe, defaults: { format: 'json' } do
+    namespace :api do
+      post :create_setup_intent, to: 'intents#create_setup_intent'
+      post :create_payment_intent, to: 'intents#create_payment_intent'
+    end
+  end
+end

--- a/spec/controllers/spree/solidus_stripe/api/intents_controller_spec.rb
+++ b/spec/controllers/spree/solidus_stripe/api/intents_controller_spec.rb
@@ -1,0 +1,132 @@
+require 'solidus_stripe_spec_helper'
+
+RSpec.describe Spree::SolidusStripe::Api::IntentsController, type: :request do
+  let(:current_api_user) do
+    user = create(:user)
+    user.generate_spree_api_key!
+    user
+  end
+  let(:order) { create(:order_ready_to_complete, user: current_api_user) }
+  let(:guest_order) { create(:order, guest_token: 'guest_token1234') }
+
+  let(:setup_intent_service) { instance_double(SolidusStripe::CreateSetupIntentForUser) }
+  let(:payment_intent_service) { instance_double(SolidusStripe::CreatePaymentIntentForOrder) }
+
+  before do
+    intent_result = {
+      client_secret: 'fake_client_secret',
+      stripe_payment_method_id: 'fake_pm_123'
+    }
+
+    allow(SolidusStripe::CreateSetupIntentForUser).to receive(:new).and_return(setup_intent_service)
+    allow(setup_intent_service).to receive(:call).and_return(intent_result)
+
+    allow(SolidusStripe::CreatePaymentIntentForOrder).to receive(:new).and_return(payment_intent_service)
+    allow(payment_intent_service).to receive(:call).and_return(intent_result)
+  end
+
+  describe '#create_setup_intent' do
+    context 'when the user is logged in' do
+      subject(:request) do
+        post spree.solidus_stripe_api_create_setup_intent_path,
+          params: { payment_method_id: 'pm_123' }
+      end
+
+      before do
+        allow(Spree.user_class).to receive(:find_by).with(hash_including(:spree_api_key)) { current_api_user }
+      end
+
+      it 'creates a setup intent' do
+        request
+
+        expect(response.status).to eq(200)
+        expect(JSON.parse(response.body)['client_secret']).to eq('fake_client_secret')
+        expect(SolidusStripe::CreateSetupIntentForUser).to have_received(:new)
+        expect(setup_intent_service).to have_received(:call).with(
+          user: current_api_user,
+          payment_method_id: 'pm_123'
+        )
+      end
+    end
+
+    context 'when the user is not logged in' do
+      subject(:request) do
+        post spree.solidus_stripe_api_create_setup_intent_path, params: { payment_method_id: 'pm_123' }
+      end
+
+      it 'cannot create a setup intent' do
+        request
+
+        expect(response.status).to eq(401)
+      end
+    end
+  end
+
+  describe '#create_payment_intent' do
+    context 'when the user is logged in' do
+      subject(:request) do
+        post spree.solidus_stripe_api_create_payment_intent_path,
+          params: { payment_method_id: 'pm_123', stripe_payment_method_id: 'fake_pm_123' }
+      end
+
+      stub_authorization!
+
+      it 'creates a payment intent' do
+        allow(Spree.user_class).to receive(:find_by).with(hash_including(:spree_api_key)) { current_api_user }
+        allow(current_api_user).to receive(:last_incomplete_spree_order).and_return(order)
+
+        request
+
+        expect(response.status).to eq(200)
+        expect(JSON.parse(response.body)['client_secret']).to eq('fake_client_secret')
+        expect(SolidusStripe::CreatePaymentIntentForOrder).to have_received(:new).with(
+          order_id: order.id,
+          payment_method_id: 'pm_123',
+          stripe_payment_method_id: 'fake_pm_123'
+        )
+        expect(payment_intent_service).to have_received(:call)
+      end
+    end
+
+    context 'when the user is not logged in' do
+      subject(:request) do
+        post spree.solidus_stripe_api_create_payment_intent_path,
+          params: { guest_token: 'guest_token1234', payment_method_id: 'pm_123',
+                    stripe_payment_method_id: 'fake_pm_123' }
+      end
+
+      it 'creates a payment intent for a guest order' do
+        allow(Spree::Order).to receive(:find_by!).with(guest_token: 'guest_token1234').and_return(guest_order)
+
+        request
+
+        expect(response.status).to eq(200)
+        expect(JSON.parse(response.body)['client_secret']).to eq('fake_client_secret')
+        expect(SolidusStripe::CreatePaymentIntentForOrder).to have_received(:new).with(
+          order_id: guest_order.id,
+          payment_method_id: 'pm_123',
+          stripe_payment_method_id: 'fake_pm_123'
+        )
+        expect(payment_intent_service).to have_received(:call)
+      end
+    end
+
+    context 'when the order is not found' do
+      subject(:request) do
+        post spree.solidus_stripe_api_create_payment_intent_path,
+          params: { guest_token: 'invalid_token', payment_method_id: 'pm_123',
+                    stripe_payment_method_id: 'fake_pm_123' }
+      end
+
+      it 'returns a not found status' do
+        allow(Spree::Order).to receive(:find_by!)
+          .with(guest_token: 'invalid_token').and_raise(ActiveRecord::RecordNotFound)
+
+        request
+
+        expect(response.status).to eq(404)
+        expect(JSON.parse(response.body)['error']).to eq('The resource you were looking for could not be found.')
+      end
+    end
+  end
+end

--- a/spec/models/solidus_stripe/customer_spec.rb
+++ b/spec/models/solidus_stripe/customer_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe SolidusStripe::Customer, type: :model do
         payment_method = create(:solidus_stripe_payment_method)
 
         stripe_customer = Stripe::Customer.construct_from(id: 'cus_123')
-        allow(Stripe::Customer).to receive(:create).with(email: 'registered@example.com').and_return(stripe_customer)
+        allow(Stripe::Customer).to receive(:create)
+          .with(email: 'registered@example.com', name: 'registered@example.com').and_return(stripe_customer)
 
         expect(
           described_class.retrieve_or_create_stripe_customer_id(order: order, payment_method: payment_method)
@@ -36,7 +37,8 @@ RSpec.describe SolidusStripe::Customer, type: :model do
         order = create(:order, user: nil, email: 'guest@example.com')
 
         stripe_customer = Stripe::Customer.construct_from(id: 'cus_123')
-        allow(Stripe::Customer).to receive(:create).with(email: 'guest@example.com').and_return(stripe_customer)
+        allow(Stripe::Customer).to receive(:create)
+          .with(email: 'guest@example.com', name: 'guest@example.com').and_return(stripe_customer)
 
         expect(
           described_class.retrieve_or_create_stripe_customer_id(order: order, payment_method: payment_method)

--- a/spec/services/solidus_stripe/create_payment_intent_for_order_spec.rb
+++ b/spec/services/solidus_stripe/create_payment_intent_for_order_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "solidus_stripe_spec_helper"
+
+RSpec.describe SolidusStripe::CreatePaymentIntentForOrder, type: :service do
+  subject(:service) do
+    described_class.new(
+      order_id: order.id,
+      payment_method_id: payment_method.id,
+      stripe_payment_method_id: 'pm_123'
+    )
+  end
+
+  let(:user) { Spree::User.create!(email: 'test@example.com', password: 'password') }
+  let(:payment_method) { SolidusStripe::PaymentMethod.create!(name: 'Stripe', type: 'SolidusStripe::PaymentMethod') }
+  let(:payment_source) {
+    SolidusStripe::PaymentSource.create!(payment_method: payment_method, stripe_payment_method_id: 'pm_123')
+  }
+  let(:order) do
+    order = create(:order_with_line_items, email: nil, user: nil)
+    allow(order.payments).to receive(:create!).and_return(order.payments.last)
+    order
+  end
+  let(:stripe_intent) { instance_double('StripeIntent', client_secret: 'secret_123') }
+
+  before do
+    allow(SolidusStripe::PaymentSource).to receive(:find_or_create_by!).with(
+      payment_method_id: payment_method.id, stripe_payment_method_id: 'pm_123'
+    ).and_return(payment_source)
+    allow(SolidusStripe::PaymentIntent).to receive(:prepare_for_payment)
+      .and_return(instance_double(SolidusStripe::PaymentIntent, stripe_intent: stripe_intent))
+  end
+
+  describe '#call' do
+    it 'creates a new payment intent and returns the client secret' do
+      result = service.call
+      expect(result[:client_secret]).to eq('secret_123')
+    end
+  end
+end

--- a/spec/services/solidus_stripe/create_setup_intent_for_user_spec.rb
+++ b/spec/services/solidus_stripe/create_setup_intent_for_user_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "solidus_stripe_spec_helper"
+
+RSpec.describe SolidusStripe::CreateSetupIntentForUser do
+  subject(:service) do
+    described_class.new(
+      find_or_create_customer_for_user: SolidusStripe::FindOrCreateCustomerForUser
+    )
+  end
+
+  let(:user) { create(:user) }
+  let(:payment_method) { create(:solidus_stripe_payment_method) }
+  let(:gateway) { instance_double(SolidusStripe::Gateway) }
+  let(:customer) { instance_double(SolidusStripe::Customer, stripe_id: 'cus_123') }
+  let(:find_or_create_customer_for_user_instance) { instance_double(SolidusStripe::FindOrCreateCustomerForUser) }
+
+  before do
+    allow(payment_method).to receive(:gateway).and_return(gateway)
+
+    allow(SolidusStripe::FindOrCreateCustomerForUser).to receive(:new)
+      .with(user: user, payment_method: payment_method)
+      .and_return(find_or_create_customer_for_user_instance)
+    allow(find_or_create_customer_for_user_instance).to receive(:call).and_return(customer)
+
+    allow(gateway).to receive(:request).and_yield
+    allow(::Stripe::SetupIntent).to receive(:create).with(
+      { customer: CGI.escape('cus_123') }
+    ).and_return({ 'client_secret' => 'example_client_secret' })
+  end
+
+  describe '#call' do
+    it 'returns the client secret' do
+      result = service.call(user: user, payment_method_id: payment_method.id)
+
+      expect(result).to eq({ client_secret: 'example_client_secret' })
+      expect(
+        SolidusStripe::FindOrCreateCustomerForUser
+      ).to have_received(:new).with(user: user, payment_method: payment_method)
+      expect(find_or_create_customer_for_user_instance).to have_received(:call)
+      expect(::Stripe::SetupIntent).to have_received(:create).with({ customer: CGI.escape('cus_123') })
+    end
+  end
+end

--- a/spec/services/solidus_stripe/find_or_create_customer_for_user_spec.rb
+++ b/spec/services/solidus_stripe/find_or_create_customer_for_user_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "solidus_stripe_spec_helper"
+
+RSpec.describe SolidusStripe::FindOrCreateCustomerForUser do
+  subject(:service) { described_class.new(user: user, payment_method: payment_method) }
+
+  let(:user) { create(:user) }
+  let(:payment_method) { instance_double(SolidusStripe::PaymentMethod) }
+  let(:customer) { instance_double(SolidusStripe::Customer, stripe_id: stripe_id) }
+
+  before do
+    allow(SolidusStripe::Customer).to receive(:find_or_create_by!).with(source: user,
+      payment_method: payment_method).and_return(customer)
+    allow(customer).to receive(:create_stripe_customer).and_return(customer)
+    allow(customer).to receive(:update!)
+    allow(customer).to receive(:id).and_return("cus_123")
+  end
+
+  describe "#call" do
+    context "when the customer already has a stripe_id" do
+      let(:stripe_id) { "cus_123" }
+
+      it "returns the existing customer without creating a new Stripe customer" do
+        result = service.call
+
+        expect(result).to eq(customer)
+        expect(SolidusStripe::Customer).to have_received(:find_or_create_by!).with(source: user,
+          payment_method: payment_method)
+        expect(customer).not_to have_received(:create_stripe_customer)
+        expect(customer).not_to have_received(:update!)
+      end
+    end
+
+    context "when the customer does not have a stripe_id" do
+      let(:stripe_id) { nil }
+
+      it "creates a new Stripe customer and updates the customer record" do
+        result = service.call
+
+        expect(result).to eq(customer)
+        expect(SolidusStripe::Customer).to have_received(:find_or_create_by!).with(source: user,
+          payment_method: payment_method)
+        expect(customer).to have_received(:create_stripe_customer)
+        expect(customer).to have_received(:update!).with(stripe_id: "cus_123")
+      end
+
+      it "creates the Stripe customer with the correct parameters" do
+        service.call
+
+        expect(customer).to have_received(:create_stripe_customer)
+      end
+
+      it "updates the customer with the Stripe customer ID" do
+        service.call
+
+        expect(customer).to have_received(:update!).with(stripe_id: "cus_123")
+      end
+    end
+  end
+end


### PR DESCRIPTION
The necessity for this PR arises from the need to occasionally create payments through an API. This functionality will also assist in providing better support for Stripe payments.

## Endpoints

### Create Setup Intent

`POST /solidus_stripe/api/create_setup_intent`

#### Params

`payment_method_id` - ID of the `SolidusStripe::PaymentMethod` record

### Create Payment Intent

`POST /solidus_stripe/api/create_payment_intent`

This endpoint loads last incomplete spree order via `last_incomplete_spree_order` method for logged in user, or takes optional `guest_token` param for guest user. 

#### Params

`payment_method_id` - ID of the `SolidusStripe::PaymentMethod` record  
`stripe_payment_method_id` - ID of the payment method, obtained by frontend from Stripe
`guest_token` - optional